### PR TITLE
Textilize descriptions

### DIFF
--- a/destijl.html
+++ b/destijl.html
@@ -137,7 +137,7 @@
         <tbody>
           {% for item in document.items %}
           <tr>
-            <td>{{item.description}}</td>
+            <td>{{item.description | textilize}}</td>
             <td class="right">{{item.quantity | precision}}</td>
             <td class="right">{{item.unit_price | precision}}</td>
             <td class="right"><strong>{{item.subtotal | money}}</strong></td>

--- a/minimal.html
+++ b/minimal.html
@@ -99,7 +99,7 @@
             <tbody>
               {% for item in document.items %}
               <tr>
-                <td>{{item.description}}</td>
+                <td>{{item.description | textilize}}</td>
                 <td class="right">{{item.quantity | precision}}</td>
                 <td class="right">{{item.unit_price | money}}</td>
                 <td class="right">{{item.subtotal | money}}</td>

--- a/newspaper.html
+++ b/newspaper.html
@@ -142,7 +142,7 @@
   <tbody>
     {% for item in document.items %}
     <tr>
-      <td class="description w322 valign-top">{{item.description}}</td>
+      <td class="description w322 valign-top">{{item.description | textilize}}</td>
       <td class="quantity w92 valign-top">{{item.quantity | precision}}</td>
       <td class="price w138 valign-top">{{item.unit_price | money}}</td>
       <td class="amount w170 valign-top"><strong>{{item.subtotal | money}}</strong></td>

--- a/professional.html
+++ b/professional.html
@@ -98,7 +98,7 @@
           <tbody>
             {% for item in document.items %}
             <tr>
-              <td>{{item.description}}</td>
+              <td>{{item.description | textilize}}</td>
               <td class="center w10per">{{item.quantity | precision}}</td>
               <td class="right w15per">{{item.unit_price | money}}</td>
               <td class="right">{{item.subtotal | money}}</td>


### PR DESCRIPTION
I found a case where html characters broke the description.
So I proposed/merged a [fix](https://github.com/recrea/quaderno/pull/2021) to escape the description.

Now users that want to render html in their item descriptions need to use the `textilize` filters.