### PR TITLE
Add verification code to the default templates

### DIFF
--- a/destijl.html
+++ b/destijl.html
@@ -219,6 +219,15 @@
           <td colspan="3" class="legal">{{document.legal | textilize}}</td>
         </tr>
         {% endif %}
+        {% if document.verification_code %}
+          <tr>
+            <td colspan="2" class="right">&nbsp;</td>
+            <td class="right">
+              {{document.verification_code}} <br><br><br>
+              {{document.verification_permalink}}
+            </td>
+          </tr>
+        {% endif %}
         <!-- // End Template Footer \\ -->
         </table>
     </div>

--- a/minimal.html
+++ b/minimal.html
@@ -160,6 +160,13 @@
     {% if document.legal != blank %}
     <p id="legal">{{document.legal | textilize}}</p>
     {% endif %}
+    {% if document.verification_code %}
+    <br>
+    <p class="right">
+      {{document.verification_code}} <br><br><br>
+      {{document.verification_permalink}}
+    </p>
+    {% endif %}
   </div>
 </body>
 </html>

--- a/newspaper.html
+++ b/newspaper.html
@@ -35,6 +35,7 @@
   .valign-bottom {vertical-align:bottom}
   .valign-top {vertical-align:top}
   .subject {font-style:italic}
+  .verification-code {text-align:right}
   address {color:#4d4d4d; font-style:italic; font-size:14px}
   .line {border-top:1px solid #ccc}
   .document-data, .contact-data {padding-top:10px}
@@ -239,6 +240,15 @@
   <tr>
     <td colspan="5" class="legal valign-top">
       <p>{{document.legal | textilize}}</p>
+    </td>
+  </tr>
+  {% endif %}
+  {% if document.verification_code %}
+  <tr>
+    <td colspan="4">&nbsp;</td>
+    <td class="valign-top verification-code">
+      <p>{{document.verification_code}}</p>
+      {{document.verification_permalink}}
     </td>
   </tr>
   {% endif %}

--- a/professional.html
+++ b/professional.html
@@ -156,6 +156,16 @@
         {% endif %}
       </td>
     </tr>
+
+    {% if document.verification_code %}
+    <tr>
+      <td class="right">&nbsp;</td>
+      <td class="right">
+        {{document.verification_code}} <br><br><br>
+        {{document.verification_permalink}}
+      </td>
+    </tr>
+    {% endif %}
   </table>
 </body>
 </html>


### PR DESCRIPTION
Display code and QR code if the connected account has any electronic Invoicing system connected (TicketBAI for now). The position is fixed and aligned to the right as we submitted it that way in the integration report. Examples:

![destijl](https://github.com/quaderno/quaderno-templates/assets/1730519/06ef161d-90e9-4c67-87f2-2df7b153d382)
![newspaper](https://github.com/quaderno/quaderno-templates/assets/1730519/e353959b-fcf9-45ec-a9bc-d201614539e3)
![minimal](https://github.com/quaderno/quaderno-templates/assets/1730519/7215109c-be44-4298-9cb4-a736ec12b85d)
![professional](https://github.com/quaderno/quaderno-templates/assets/1730519/5aef6196-17b3-4191-b36d-23833896fb44)
