### PR TITLE
Replace reprint badge with inline qualifier

### DIFF
--- a/gestalt.html
+++ b/gestalt.html
@@ -64,8 +64,8 @@
     .badge-paid        { background-color: #A4F4C0; color: #016630; border: 1px solid rgba(1,102,48,.1); }
     .badge-overdue     { background-color: #FFE2E2; color: #9F0712; border: 1px solid rgba(159,7,18,.1); }
     .badge-canceled    { background-color: #E5E5E5; color: #404040; border: 1px solid rgba(64,64,64,.2); }
-    .badge-original    { background-color: #EFF6FF; color: #1D4ED8; border: 1px solid rgba(29,78,216,.15); }
-    .badge-duplicate   { background-color: #FFF7ED; color: #9A3412; border: 1px solid rgba(154,52,18,.15); }
+    .reprint-qualifier           { font-size: 13px; font-style: italic; font-weight: 600; color: #525252; }
+    .reprint-qualifier--original { color: #A3A3A3; }
 
     .sandbox-banner {
       background-color: #FEF3C7;
@@ -245,16 +245,17 @@
             {% else %}<span class="badge badge-{{document.state}}">{{ document.state | capitalize }}</span>
             {% endif %}
           </div>
-          <div class="doc-number">{{labels.number}} {{ document.number }}</div>
-          {% if reprint.applicable %}
-          <div class="doc-number" style="margin-top:2px;">
-            {% if reprint.reprint_number == 1 %}
-              <span class="badge badge-original">{{ reprint.print_status }}</span>
-            {% else %}
-              <span class="badge badge-duplicate">{{ reprint.print_status }} #{{ reprint.reprint_number }}</span>
+          <div class="doc-number">
+            {{labels.number}} {{ document.number }}
+            {% if reprint.applicable %} 
+              &nbsp;·&nbsp; 
+              {% if reprint.reprint_number == 1 %}
+                <span class="reprint-qualifier reprint-qualifier--original">{{ reprint.print_status }}</span>
+              {% else %}
+                <span class="reprint-qualifier">{{ reprint.print_status }} #{{ reprint.reprint_number }}</span>
+              {% endif %}
             {% endif %}
           </div>
-          {% endif %}
         </td>
         <td class="header-logo-cell">
           {% if account.logo_url != blank %}


### PR DESCRIPTION
The reprint element was reusing the .badge component, creating two problems: 
- Semantic confusion with the payment status badges
- Visually orphaned position below the invoice number line

This replaces it with an inline text qualifier on the same line as the invoice number, separated by a mid-dot. 

Two states: **Original** (muted) and **Duplicate** (visible), both italic.